### PR TITLE
Fix false positives: .exec() receiver, window local var, cross-file taint

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillsafe",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "type": "module",
   "description": "SafeSkill CLI — scan AI tool skills for security risks and prompt injection",
   "author": "SafeSkill",

--- a/packages/scanner/src/analyzers/ast-analyzer.ts
+++ b/packages/scanner/src/analyzers/ast-analyzer.ts
@@ -95,6 +95,9 @@ const CALL_CATEGORY_MAP: Record<string, DetectorCategory> = {
 function getCategoryForCall(expression: string): DetectorCategory | null {
   const parts = expression.split('.');
   const method = parts[parts.length - 1]!;
+  // 'exec' is ambiguous (RegExp.exec, Pipeline.exec, etc.)
+  // Only categorize as process-spawn when it's a bare exec() call.
+  if (method === 'exec' && parts.length > 1) return null;
   return CALL_CATEGORY_MAP[method] ?? null;
 }
 

--- a/packages/scanner/src/analyzers/taint-tracker.ts
+++ b/packages/scanner/src/analyzers/taint-tracker.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import type { TaintFlow, Severity } from '@safeskill/shared';
 import type { FileAnalysis, CallInfo, ImportInfo } from './ast-analyzer.js';
 import { DANGEROUS_MODULES, SENSITIVE_PATHS, SENSITIVE_ENV_VARS } from '@safeskill/shared';
@@ -139,15 +140,21 @@ export function trackTaint(fileAnalyses: FileAnalysis[]): TaintFlow[] {
   // Check if sink-files import from source-files (cross-file exfiltration)
   for (const sinkFile of filesWithSinks) {
     for (const imp of sinkFile.file.imports) {
-      // Check if this import points to a file that has sources
-      const importPath = imp.module.replace(/^\.\/|\.ts$|\.js$|\.mjs$/g, '');
+      // Only relative imports can reference local source files
+      if (!imp.module.startsWith('.')) continue;
+
+      // Resolve import path relative to the importing file's directory
+      const sinkDir = path.dirname(sinkFile.file.filePath);
+      const resolvedImport = path.join(sinkDir, imp.module).replace(/\\/g, '/');
+      const normalizedImport = resolvedImport.replace(/\.(ts|js|mjs|cjs)$/, '');
 
       for (const sourceFile of filesWithSources) {
         if (sinkFile.file.filePath === sourceFile.file.filePath) continue;
 
-        const sourceName = sourceFile.file.filePath.replace(/\.ts$|\.js$|\.mjs$/g, '');
-        const matches = sourceName.endsWith(importPath) ||
-          importPath.endsWith(sourceName.split('/').pop()!.replace(/\.\w+$/, ''));
+        const normalizedSource = sourceFile.file.filePath.replace(/\.(ts|js|mjs|cjs)$/, '');
+        // Strict match: resolved import must equal source path or source/index
+        const matches = normalizedSource === normalizedImport ||
+          normalizedSource === `${normalizedImport}/index`;
 
         if (!matches) continue;
 

--- a/packages/scanner/src/detectors/obfuscation.ts
+++ b/packages/scanner/src/detectors/obfuscation.ts
@@ -54,12 +54,25 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
     }
   }
 
+  // Collect locally declared variable and parameter names so we don't confuse
+  // a local `window` array (etc.) with the browser global.
+  const localDeclarations = new Set<string>();
+  for (const decl of sourceFile.getDescendantsOfKind(SyntaxKind.VariableDeclaration)) {
+    localDeclarations.add(decl.getName());
+  }
+  for (const param of sourceFile.getDescendantsOfKind(SyntaxKind.Parameter)) {
+    localDeclarations.add(param.getName());
+  }
+
   // Detect bracket notation access to dangerous objects: process['env'], require['resolve'], etc.
   for (const access of sourceFile.getDescendantsOfKind(SyntaxKind.ElementAccessExpression)) {
     const obj = access.getExpression();
     const objText = obj.getText();
 
     if (!DANGEROUS_BRACKET_TARGETS.has(objText)) continue;
+
+    // Skip if this name is a locally declared variable/parameter, not the global
+    if (localDeclarations.has(objText)) continue;
 
     const arg = access.getArgumentExpression();
     if (!arg) continue;

--- a/packages/scanner/src/detectors/process-spawn.ts
+++ b/packages/scanner/src/detectors/process-spawn.ts
@@ -44,8 +44,25 @@ function hasTemplateOrConcatInArgs(call: ReturnType<SourceFile['getDescendantsOf
   return false;
 }
 
+function hasChildProcessImport(sourceFile: SourceFile): boolean {
+  for (const decl of sourceFile.getImportDeclarations()) {
+    if (CHILD_PROCESS_MODULES.has(decl.getModuleSpecifierValue())) return true;
+  }
+  for (const call of sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+    const expr = call.getExpression();
+    if (expr.getKind() !== SyntaxKind.Identifier || expr.getText() !== 'require') continue;
+    const args = call.getArguments();
+    if (args.length === 0) continue;
+    const firstArg = args[0]!;
+    if (firstArg.getKind() !== SyntaxKind.StringLiteral) continue;
+    if (CHILD_PROCESS_MODULES.has(firstArg.getText().slice(1, -1))) return true;
+  }
+  return false;
+}
+
 export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
   const findings: CodeFinding[] = [];
+  const fileImportsChildProcess = hasChildProcessImport(sourceFile);
 
   // Check imports of child_process / vm
   for (const decl of sourceFile.getImportDeclarations()) {
@@ -132,6 +149,12 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
     const methodName = parts[parts.length - 1]!;
 
     if (SPAWN_METHODS.has(methodName)) {
+      // 'exec' is ambiguous — RegExp.exec(), ioredis Pipeline.exec(), etc.
+      // Only flag receiver-qualified .exec() calls if the file imports child_process.
+      if (methodName === 'exec' && parts.length > 1 && !fileImportsChildProcess) {
+        continue;
+      }
+
       const hasInjectionRisk = hasTemplateOrConcatInArgs(call);
 
       let description = `Spawns child process: ${methodName}()`;


### PR DESCRIPTION
## Summary

Fixes #3 — three categories of false positives reported from the [nanohype scan](https://github.com/nanohype/nanohype/pull/60):

- **`.exec()` receiver ambiguity**: `RegExp.exec()` and `ioredis Pipeline.exec()` were flagged as "spawns child process." Now only flags receiver-qualified `.exec()` calls when the file actually imports `child_process`. Bare `exec()` calls remain flagged.
- **`window` variable name**: Local variables named `window` (e.g. sliding-window arrays) were flagged as browser global obfuscation. Now collects locally declared variables/parameters and skips bracket-access findings on them.
- **Cross-file taint tracking**: Loose `endsWith` filename matching caused spurious source→sink flows between unrelated template skeletons sharing common names like `index` or `client`. Replaced with proper relative import path resolution — only relative imports are considered, and paths are resolved against the importing file's directory.
- **`getCategoryForCall`**: Receiver-qualified `.exec()` calls (e.g. `regex.exec`) no longer categorized as `process-spawn` in file analysis metadata.

## Test plan

- [ ] Run scan against nanohype/nanohype and verify the 5 RegExp/Redis `.exec()` criticals are eliminated
- [ ] Verify `circuit-breaker.ts:62` `window[0]` is no longer flagged
- [ ] Verify cross-file taint flows between unrelated template skeletons are eliminated
- [ ] Verify true positives (Function constructor, child_process imports) still detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)