### PR TITLE
Fix MCP false positives, add .safeskillignore & participation badge

### DIFF
--- a/apps/api-worker/src/index.ts
+++ b/apps/api-worker/src/index.ts
@@ -72,9 +72,11 @@ export default {
       }
 
       // GET /api/badge/:slug — SVG badge image
+      // Optional ?style=participation for a "scanned by" badge without numeric score
       const badgeMatch = path.match(/^\/api\/badge\/([a-z0-9\-._]+)$/i);
       if (badgeMatch && request.method === 'GET') {
-        return handleBadge(badgeMatch[1], env);
+        const style = url.searchParams.get('style') ?? undefined;
+        return handleBadge(badgeMatch[1], env, style);
       }
 
       // Health

--- a/apps/api-worker/src/routes/badge.ts
+++ b/apps/api-worker/src/routes/badge.ts
@@ -83,7 +83,37 @@ function notFoundBadge(): string {
 </svg>`;
 }
 
-export async function handleBadge(slug: string, env: Env): Promise<Response> {
+function makeParticipationBadgeSvg(): string {
+  const label = 'safeskill';
+  const value = 'scanned';
+  const color = '#2196f3'; // blue — neutral, indicates participation
+
+  const labelWidth = 70;
+  const valueWidth = 65;
+  const totalWidth = labelWidth + valueWidth;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="20" role="img" aria-label="${label}: ${value}">
+  <title>${label}: ${value}</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="${totalWidth}" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="${labelWidth}" height="20" fill="#555"/>
+    <rect x="${labelWidth}" width="${valueWidth}" height="20" fill="${color}"/>
+    <rect width="${totalWidth}" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="11">
+    <text aria-hidden="true" x="${labelWidth / 2}" y="15" fill="#010101" fill-opacity=".3">${label}</text>
+    <text x="${labelWidth / 2}" y="14">${label}</text>
+    <text aria-hidden="true" x="${labelWidth + valueWidth / 2}" y="15" fill="#010101" fill-opacity=".3">${value}</text>
+    <text x="${labelWidth + valueWidth / 2}" y="14">${value}</text>
+  </g>
+</svg>`;
+}
+
+export async function handleBadge(slug: string, env: Env, style?: string): Promise<Response> {
   const headers = {
     'Content-Type': 'image/svg+xml',
     'Cache-Control': 'public, max-age=3600, s-maxage=3600',
@@ -99,6 +129,12 @@ export async function handleBadge(slug: string, env: Env): Promise<Response> {
     if (!result?.overallScore && result?.overallScore !== 0) {
       return new Response(notFoundBadge(), { status: 200, headers });
     }
+
+    // ?style=participation returns a "scanned" badge without numeric score
+    if (style === 'participation') {
+      return new Response(makeParticipationBadgeSvg(), { status: 200, headers });
+    }
+
     return new Response(makeBadgeSvg(result.overallScore), { status: 200, headers });
   } catch {
     return new Response(notFoundBadge(), { status: 200, headers });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillsafe",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "type": "module",
   "description": "SafeSkill CLI — scan AI tool skills for security risks and prompt injection",
   "author": "SafeSkill",

--- a/packages/cli/src/reporter.ts
+++ b/packages/cli/src/reporter.ts
@@ -96,23 +96,25 @@ export function printReport(result: ScanResult): void {
   // Detailed findings (top 10)
   // Filter out expected findings for tool packages and test fixtures from the display
   const CLI_EXPECTED_CATEGORIES = new Set(['process-spawn', 'filesystem-access', 'env-access']);
+  const MCP_EXPECTED_CATEGORIES = new Set(['process-spawn', 'filesystem-access', 'env-access', 'network-access']);
   const isCli = result.packageType === 'cli-tool';
   const isMcp = result.packageType === 'mcp-server';
   const isToolPackage = isCli || isMcp;
+  const expectedCategories = isMcp ? MCP_EXPECTED_CATEGORIES : CLI_EXPECTED_CATEGORIES;
 
   const allFindings = [
     ...result.codeFindings.map(f => ({ ...f, type: 'code' as const })),
     ...result.promptFindings.map(f => ({ ...f, type: 'prompt' as const })),
   ]
     .filter(f => !f.isTestFixture)
-    .filter(f => !(isToolPackage && 'category' in f && CLI_EXPECTED_CATEGORIES.has(f.category as string)))
+    .filter(f => !(isToolPackage && 'category' in f && expectedCategories.has(f.category as string)))
     .sort((a, b) => severityOrder(b.severity) - severityOrder(a.severity));
 
   if (isCli) {
     console.log(chalk.dim('  ℹ CLI tool detected — process-spawn, filesystem, and env-access findings are expected and excluded.'));
     console.log('');
   } else if (isMcp) {
-    console.log(chalk.dim('  ℹ MCP server detected — process-spawn, filesystem, and env-access findings are expected and excluded.'));
+    console.log(chalk.dim('  ℹ MCP server detected — process-spawn, filesystem, network, and env-access findings are expected and excluded.'));
     console.log('');
   }
 
@@ -162,10 +164,14 @@ export function printReport(result: ScanResult): void {
 
   // Badge
   const slug = packageToSlug(result.packageName);
-  console.log(chalk.bold('  Badge:'));
+  console.log(chalk.bold('  Badges:'));
   console.log(chalk.dim('  Add to your README:'));
   console.log('');
+  console.log(chalk.dim('  Score badge (shows numeric score):'));
   console.log(`  ${chalk.cyan(`[![SafeSkill](https://safeskill.dev/api/badge/${slug})](https://safeskill.dev/scan/${slug})`)}`);
+  console.log('');
+  console.log(chalk.dim('  Participation badge (no numeric score):'));
+  console.log(`  ${chalk.cyan(`[![SafeSkill Scanned](https://safeskill.dev/api/badge/${slug}?style=participation)](https://safeskill.dev/scan/${slug})`)}`);
   console.log('');
 }
 

--- a/packages/scanner/src/analyzers/ignore-file.ts
+++ b/packages/scanner/src/analyzers/ignore-file.ts
@@ -1,0 +1,141 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+import type { CodeFinding, PromptFinding, TaintFlow } from '@safeskill/shared';
+
+/**
+ * Parses a `.safeskillignore` file and returns a filter that can suppress
+ * documented false-positive findings before scoring.
+ *
+ * File format (line-based, similar to .gitignore):
+ *
+ *   # Comment lines start with #
+ *   install-scripts          # Ignore all findings in this category
+ *   network-access:exfil*    # Ignore network-access findings whose description matches glob
+ *   taint:process.env->*     # Ignore taint flows from env to any sink
+ *   file:src/tools/**        # Ignore all findings in matching file paths
+ *
+ * Supported prefixes:
+ *   <category>                — suppress all findings in that category
+ *   <category>:<glob>         — suppress findings whose description matches
+ *   taint:<source>-><sink>    — suppress taint flows (use * for wildcard)
+ *   file:<glob>               — suppress findings in matching file paths
+ */
+
+export interface IgnoreRules {
+  /** Full categories to ignore */
+  categories: Set<string>;
+  /** Category + description pattern pairs */
+  categoryPatterns: Array<{ category: string; pattern: RegExp }>;
+  /** Taint flow source→sink patterns */
+  taintPatterns: Array<{ source: RegExp; sink: RegExp }>;
+  /** File path patterns */
+  filePatterns: RegExp[];
+}
+
+function globToRegex(glob: string): RegExp {
+  const escaped = glob
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '__DOUBLESTAR__')
+    .replace(/\*/g, '[^/]*')
+    .replace(/__DOUBLESTAR__/g, '.*');
+  return new RegExp(`^${escaped}$`, 'i');
+}
+
+export function parseIgnoreRules(content: string): IgnoreRules {
+  const rules: IgnoreRules = {
+    categories: new Set(),
+    categoryPatterns: [],
+    taintPatterns: [],
+    filePatterns: [],
+  };
+
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.replace(/#.*$/, '').trim();
+    if (!line) continue;
+
+    if (line.startsWith('file:')) {
+      const glob = line.slice(5).trim();
+      if (glob) rules.filePatterns.push(globToRegex(glob));
+    } else if (line.startsWith('taint:')) {
+      const spec = line.slice(6).trim();
+      const arrowIdx = spec.indexOf('->');
+      if (arrowIdx > 0) {
+        const source = spec.slice(0, arrowIdx).trim();
+        const sink = spec.slice(arrowIdx + 2).trim();
+        rules.taintPatterns.push({
+          source: globToRegex(source),
+          sink: globToRegex(sink),
+        });
+      }
+    } else if (line.includes(':')) {
+      const colonIdx = line.indexOf(':');
+      const category = line.slice(0, colonIdx).trim();
+      const pattern = line.slice(colonIdx + 1).trim();
+      if (category && pattern) {
+        rules.categoryPatterns.push({ category, pattern: globToRegex(pattern) });
+      }
+    } else {
+      rules.categories.add(line);
+    }
+  }
+
+  return rules;
+}
+
+export async function loadIgnoreRules(dir: string): Promise<IgnoreRules | null> {
+  try {
+    const content = await readFile(path.join(dir, '.safeskillignore'), 'utf-8');
+    return parseIgnoreRules(content);
+  } catch {
+    return null;
+  }
+}
+
+export function applyIgnoreRules(
+  codeFindings: CodeFinding[],
+  promptFindings: PromptFinding[],
+  taintFlows: TaintFlow[],
+  rules: IgnoreRules,
+): {
+  codeFindings: CodeFinding[];
+  promptFindings: PromptFinding[];
+  taintFlows: TaintFlow[];
+} {
+  const matchesFile = (filePath: string) =>
+    rules.filePatterns.some(re => re.test(filePath));
+
+  const matchesCategoryPattern = (category: string, description: string) =>
+    rules.categoryPatterns.some(cp =>
+      cp.category === category && cp.pattern.test(description)
+    );
+
+  const filteredCode = codeFindings.filter(f => {
+    if (rules.categories.has(f.category)) return false;
+    if (matchesFile(f.location.file)) return false;
+    if (matchesCategoryPattern(f.category, f.description)) return false;
+    return true;
+  });
+
+  const filteredPrompt = promptFindings.filter(f => {
+    if (rules.categories.has(f.category)) return false;
+    if (matchesFile(f.location.file)) return false;
+    if (matchesCategoryPattern(f.category, f.description)) return false;
+    return true;
+  });
+
+  const filteredTaint = taintFlows.filter(f => {
+    if (rules.taintPatterns.some(tp =>
+      tp.source.test(f.source.type) && tp.sink.test(f.sink.type)
+    )) return false;
+    // Also filter if source or sink file matches a file pattern
+    if (matchesFile(f.source.location.file)) return false;
+    if (matchesFile(f.sink.location.file)) return false;
+    return true;
+  });
+
+  return {
+    codeFindings: filteredCode,
+    promptFindings: filteredPrompt,
+    taintFlows: filteredTaint,
+  };
+}

--- a/packages/scanner/src/analyzers/manifest-analyzer.ts
+++ b/packages/scanner/src/analyzers/manifest-analyzer.ts
@@ -54,6 +54,29 @@ const DANGEROUS_INSTALL_PATTERNS = [
   /powershell/i,
 ];
 
+/**
+ * Install scripts that are benign — common build/setup commands that
+ * do not download, execute remote code, or modify system state.
+ * These get severity 'info' instead of the default 'high'.
+ */
+const BENIGN_INSTALL_PATTERNS = [
+  /^\s*echo\s/,                // echo "Done!", echo "Install complete"
+  /^\s*echo$/,                 // bare echo (prints newline)
+  /^\s*true\s*$/,              // no-op
+  /^\s*exit\s+0\s*$/,          // explicit success exit
+  /^\s*tsc\b/,                 // TypeScript compilation
+  /^\s*node\s+[\w./\-]+\.m?[jt]s/,  // node build.js, node scripts/postinstall.js (not -e)
+  /^\s*husky\s/,               // husky install
+  /^\s*patch-package\b/,       // patch-package
+  /^\s*ngcc\b/,                // Angular compiler
+  /^\s*prisma\s+generate\b/,   // Prisma client generation
+  /^\s*esbuild\b/,             // esbuild
+  /^\s*rimraf\b/,              // rimraf (cleanup)
+  /^\s*shx\s/,                 // shx (shell commands cross-platform)
+  /^\s*opencollective\b/,      // opencollective postinstall
+  /^\s*is-ci\b/,               // is-ci && ... (conditional CI scripts)
+];
+
 export async function analyzeManifest(dir: string): Promise<ManifestResult> {
   const findings: CodeFinding[] = [];
   let hasInstallScripts = false;
@@ -118,12 +141,21 @@ export async function analyzeManifest(dir: string): Promise<ManifestResult> {
     let severity: CodeFinding['severity'] = 'high';
     let description = `Has ${key} script: "${script}"`;
 
+    // Check for dangerous patterns first (highest priority)
+    let isDangerous = false;
     for (const pattern of DANGEROUS_INSTALL_PATTERNS) {
       if (pattern.test(script)) {
         severity = 'critical';
         description = `${key} script downloads/executes remote code: "${script}"`;
+        isDangerous = true;
         break;
       }
+    }
+
+    // If not dangerous, check if it's a known benign pattern
+    if (!isDangerous && BENIGN_INSTALL_PATTERNS.some(p => p.test(script))) {
+      severity = 'info';
+      description = `Has ${key} script (benign): "${script}"`;
     }
 
     findings.push({

--- a/packages/scanner/src/detectors/network-access.ts
+++ b/packages/scanner/src/detectors/network-access.ts
@@ -142,11 +142,15 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
       }
     }
 
-    // Co-occurrence: fs import + network call = critical
-    const severity: Severity = hasFsImport ? 'critical' : hasExternalUrl ? 'high' : 'medium';
+    // Determine severity based on what we can observe at the detector level.
+    // Co-occurrence of fs + network is a signal, but NOT confirmed exfiltration —
+    // the taint tracker handles actual data-flow analysis with proper context.
+    // MCP servers and CLI tools legitimately need both fs and network access.
+    let severity: Severity = hasExternalUrl ? 'high' : 'medium';
 
-    if (hasFsImport && severity === 'critical') {
-      description += ' (co-occurs with filesystem access — potential data exfiltration)';
+    if (hasFsImport) {
+      severity = severity === 'medium' ? 'medium' : 'high';
+      description += ' (co-occurs with filesystem access)';
     }
 
     findings.push({
@@ -155,7 +159,7 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
       location: getLocation(sourceFile, call.getStart(), relPath),
       description,
       codeSnippet: truncate(call.getText().trim(), 120),
-      confidence: severity === 'critical' ? 0.9 : 0.8,
+      confidence: hasExternalUrl ? 0.9 : 0.8,
     });
   }
 

--- a/packages/scanner/src/index.ts
+++ b/packages/scanner/src/index.ts
@@ -9,6 +9,7 @@ import { trackTaint } from './analyzers/taint-tracker.js';
 import { correlateCodeContent } from './analyzers/correlation.js';
 import { calculateScore } from './scoring/calculator.js';
 import { inferPermissions } from './analyzers/permission-inferrer.js';
+import { loadIgnoreRules, applyIgnoreRules } from './analyzers/ignore-file.js';
 import { nanoid } from './utils.js';
 
 export interface ScanOptions {
@@ -41,7 +42,7 @@ export async function scan(options: ScanOptions): Promise<ScanResult> {
   ]);
 
   // === Combine code findings from all layers ===
-  const codeFindings: CodeFinding[] = [
+  let codeFindings: CodeFinding[] = [
     ...patternResults.findings,
     ...manifestResults.findings,
     ...depResults.findings,
@@ -49,16 +50,25 @@ export async function scan(options: ScanOptions): Promise<ScanResult> {
   ];
 
   // === LAYER 2 continued: Taint tracking on AST results ===
-  const taintFlows: TaintFlow[] = trackTaint(astResults.fileAnalyses);
+  let taintFlows: TaintFlow[] = trackTaint(astResults.fileAnalyses);
+
+  let promptFindings: PromptFinding[] = promptResults.findings;
+
+  // === Apply .safeskillignore rules (if present) ===
+  const ignoreRules = await loadIgnoreRules(dir);
+  if (ignoreRules) {
+    const filtered = applyIgnoreRules(codeFindings, promptFindings, taintFlows, ignoreRules);
+    codeFindings = filtered.codeFindings;
+    promptFindings = filtered.promptFindings;
+    taintFlows = filtered.taintFlows;
+  }
 
   // === LAYER 3: Cross-file intelligence ===
   const mismatches: MismatchFinding[] = correlateCodeContent(
     codeFindings,
-    promptResults.findings,
+    promptFindings,
     contentFiles,
   );
-
-  const promptFindings: PromptFinding[] = promptResults.findings;
 
   // === Infer permissions ===
   const permissions: PermissionManifest = inferPermissions(

--- a/packages/scanner/src/scoring/calculator.ts
+++ b/packages/scanner/src/scoring/calculator.ts
@@ -25,13 +25,25 @@ export interface ScoreInput {
 }
 
 /**
- * Categories of findings that are EXPECTED for CLI tools and dev tools.
+ * Categories of findings that are EXPECTED for CLI tools.
  * These should not penalize the score when the package is a CLI.
  */
 const CLI_EXPECTED_CATEGORIES = new Set([
   'process-spawn',
   'filesystem-access',
   'env-access',
+]);
+
+/**
+ * Categories of findings that are EXPECTED for MCP servers.
+ * MCP servers legitimately use filesystem, network, process, and env access
+ * as part of their core tool functionality — penalizing these is wrong.
+ */
+const MCP_EXPECTED_CATEGORIES = new Set([
+  'process-spawn',
+  'filesystem-access',
+  'env-access',
+  'network-access',
 ]);
 
 export interface ScoreOutput {
@@ -54,16 +66,19 @@ export function calculateScore(
   mismatches: MismatchFinding[],
   meta: ScoreInput,
 ): ScoreOutput {
-  // For CLI tools and MCP servers, filter out expected findings from dangerous API scoring.
-  // CLI tools and MCP servers NEED child_process, fs, and env access — penalizing them is wrong.
+  // For CLI tools and MCP servers, filter out expected findings from scoring.
+  // CLI tools NEED child_process, fs, and env access.
+  // MCP servers additionally NEED network access as core tool functionality.
   const isCli = meta.packageType === 'cli-tool';
   const isMcp = meta.packageType === 'mcp-server';
   const isToolPackage = isCli || isMcp;
+  const expectedCategories = isMcp ? MCP_EXPECTED_CATEGORIES : CLI_EXPECTED_CATEGORIES;
   const contextFindings = isToolPackage
-    ? codeFindings.filter(f => !CLI_EXPECTED_CATEGORIES.has(f.category))
+    ? codeFindings.filter(f => !expectedCategories.has(f.category))
     : codeFindings;
 
-  // Also reduce taint flow severity for tool packages accessing their own config
+  // Reduce taint flow noise for tool packages (CLI/MCP servers).
+  // These packages legitimately read files, env vars, and make network requests.
   const contextTaintFlows = isToolPackage
     ? taintFlows.filter(f => {
         // Tool reading its own config dir is not exfiltration
@@ -71,7 +86,23 @@ export function calculateScore(
           !f.source.description.includes('.ssh') &&
           !f.source.description.includes('.aws') &&
           !f.source.description.includes('.gnupg');
-        return !isOwnConfig;
+        if (isOwnConfig) return false;
+
+        // For tool packages, reading env vars and sending network requests is the
+        // SECURE pattern (e.g. reading OPENAI_API_KEY from env to call an API).
+        // Only flag env flows if they access truly sensitive non-API-key vars
+        // like SSH keys or bulk access.
+        const isEnvToNetwork = f.source.type === 'process.env' &&
+          !f.source.description.includes('Bulk') &&
+          (f.sink.type.startsWith('fetch') ||
+           f.sink.type.startsWith('http') ||
+           f.sink.type.startsWith('https') ||
+           f.sink.type.startsWith('axios') ||
+           f.sink.type.startsWith('got') ||
+           f.sink.type.startsWith('request'));
+        if (isEnvToNetwork) return false;
+
+        return true;
       })
     : taintFlows;
 


### PR DESCRIPTION
## Summary
- **Fix 3 categories of MCP server false positives** reported in [aeoess/agent-passport-mcp#1](https://github.com/aeoess/agent-passport-mcp/pull/1#issuecomment-4226072700): benign postinstall scripts, fetch+fs co-occurrence, env-var→network taint flows
- **Add `.safeskillignore` support** so package authors can whitelist documented false positives with a simple line-based file format
- **Add participation badge** (`?style=participation`) — a "scanned by SafeSkill" badge without numeric score, for authors who want to show participation without a potentially misleading number
- Bump CLI to v0.3.0

## Changes

### False positive fixes
| False Positive | Root Cause | Fix |
|---|---|---|
| `postinstall: "echo Done"` flagged as high severity | All install scripts defaulted to `high` | Added benign script detection (`echo`, `tsc`, `husky install`, etc.) → `info` severity |
| fetch+fs co-occurrence flagged as critical exfiltration | Network detector auto-escalated when fs was co-imported | Removed auto-escalation (taint tracker handles real data flows); added `network-access` to MCP expected categories |
| `process.env.API_KEY` → `fetch()` flagged as critical taint | Taint tracker didn't distinguish tool packages from libraries | Filter env→network flows for CLI/MCP packages (env vars are the secure pattern) |

### New features
- **`.safeskillignore`**: category suppression, category+pattern matching, taint flow filtering, file path exclusion
- **Participation badge**: blue "safeskill: scanned" SVG via `?style=participation` query param

### Files changed
- `packages/scanner/src/analyzers/manifest-analyzer.ts` — benign install script detection
- `packages/scanner/src/detectors/network-access.ts` — remove co-occurrence escalation
- `packages/scanner/src/scoring/calculator.ts` — MCP expected categories, env→network filtering
- `packages/scanner/src/analyzers/ignore-file.ts` — **new** .safeskillignore parser + filter
- `packages/scanner/src/index.ts` — integrate ignore rules into pipeline
- `packages/cli/src/reporter.ts` — MCP message update, participation badge output
- `packages/cli/package.json` — version bump to 0.3.0
- `apps/api-worker/src/routes/badge.ts` — participation badge SVG
- `apps/api-worker/src/index.ts` — style query param routing

## Test plan
- [ ] `npx skillsafe scan` on an MCP server package (e.g. agent-passport-mcp) — verify no false positive criticals
- [ ] Scan a package with a benign `postinstall: "echo done"` — verify info severity not high
- [ ] Add `.safeskillignore` to a test package — verify findings are suppressed
- [ ] Hit `/api/badge/SLUG?style=participation` — verify blue "scanned" badge SVG
- [ ] Scan a regular library — verify no regression in detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)