### PR TITLE
Fix CLI/browser automation/security doc false positives

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillsafe",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "SafeSkill CLI — scan AI tool skills for security risks and prompt injection",
   "author": "SafeSkill",

--- a/packages/scanner/src/analyzers/taint-tracker.ts
+++ b/packages/scanner/src/analyzers/taint-tracker.ts
@@ -218,6 +218,26 @@ function findSources(file: FileAnalysis): SourceInfo[] {
   return sources;
 }
 
+const LOCALHOST_PATTERNS = /\b(localhost|127\.\d+\.\d+\.\d+|0\.0\.0\.0|::1)\b/;
+
+/**
+ * Returns true if all URL arguments in a call target localhost/loopback.
+ * Local network calls are not exfiltration sinks.
+ */
+function targetsLocalhost(args: string[]): boolean {
+  const urlArgs = args.filter(a => /https?:\/\//.test(a) || LOCALHOST_PATTERNS.test(a));
+  if (urlArgs.length === 0) return false;
+  return urlArgs.every(a => LOCALHOST_PATTERNS.test(a));
+}
+
+/**
+ * Server-side listeners (createServer) accept connections — they're not sinks.
+ */
+const SERVER_PATTERNS = new Set([
+  'http.createServer', 'https.createServer', 'net.createServer',
+  'dgram.createSocket',
+]);
+
 function findSinks(file: FileAnalysis): SourceInfo[] {
   const sinks: SourceInfo[] = [];
   const networkModules: readonly string[] = DANGEROUS_MODULES.network;
@@ -226,6 +246,12 @@ function findSinks(file: FileAnalysis): SourceInfo[] {
   );
 
   for (const call of file.callExpressions) {
+    // Server listeners accept inbound connections — not exfiltration sinks
+    if (SERVER_PATTERNS.has(call.expression)) continue;
+
+    // Skip localhost/loopback calls — they don't exfiltrate data
+    if (targetsLocalhost(call.arguments)) continue;
+
     const match = SINK_PATTERNS[call.expression];
     if (match) {
       sinks.push({

--- a/packages/scanner/src/detectors/install-scripts.ts
+++ b/packages/scanner/src/detectors/install-scripts.ts
@@ -48,8 +48,40 @@ function getLocation(sourceFile: SourceFile, pos: number, relPath: string) {
   return { file: relPath, line, column };
 }
 
+/**
+ * Whether a file path looks like it's referenced by an install script.
+ * Install scripts typically reference files like `scripts/postinstall.js`,
+ * `install.js`, etc. Files that aren't install scripts get reduced severity
+ * for download-and-execute patterns since the same patterns are common in
+ * legitimate tools (SSRF guards, browser automation, API clients).
+ */
+function looksLikeInstallScriptFile(relPath: string): boolean {
+  const lower = relPath.toLowerCase();
+  return (
+    lower.includes('postinstall') ||
+    lower.includes('preinstall') ||
+    lower.includes('install.') ||
+    lower.includes('scripts/setup') ||
+    lower.includes('scripts/prepare')
+  );
+}
+
+/**
+ * SSRF guard / security validation patterns.
+ * When functions with these names appear near fetch+exec code, it's a strong
+ * signal that the code is VALIDATING requests, not maliciously executing them.
+ * The security mechanism should not be flagged as the vulnerability.
+ */
+const SECURITY_GUARD_PATTERNS = /\b(validate|isPrivate|isLocal|blockList|blocklist|allowList|allowlist|denyList|denylist|ssrf|sanitize|safelist|safeList|isAllowed|isBlocked|checkUrl|verifyUrl|filterUrl)\b/i;
+
 export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
   const findings: CodeFinding[] = [];
+  const isInstallScript = looksLikeInstallScriptFile(relPath);
+
+  // Check if the file contains security guard patterns (SSRF validation, allowlists, etc.)
+  // If so, the fetch+exec combination is likely defensive, not malicious.
+  const fileText = sourceFile.getFullText();
+  const hasSecurityGuards = SECURITY_GUARD_PATTERNS.test(fileText);
 
   const allCalls = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression);
 
@@ -75,23 +107,31 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
   }
 
   // Pattern 1: fetch/http.get followed by eval — download-and-execute
+  // In actual install scripts this is critical. In regular source files (CLI tools,
+  // MCP servers, browser automation) fetch+exec co-occurrence is common and benign.
+  // If security guards (SSRF validators, allowlists) are present, the code is
+  // likely defensive — the security mechanism should not be flagged as malicious.
   if (hasDownload.size > 0 && hasExecute.size > 0) {
-    // Find the download call for location
-    for (const call of allCalls) {
-      const exprText = call.getExpression().getText();
-      const parts = exprText.split('.');
-      const methodName = parts[parts.length - 1]!;
+    // Skip entirely if security guard patterns are present in a non-install file
+    if (isInstallScript || !hasSecurityGuards) {
+      for (const call of allCalls) {
+        const exprText = call.getExpression().getText();
+        const parts = exprText.split('.');
+        const methodName = parts[parts.length - 1]!;
 
-      if (DOWNLOAD_FUNCTIONS.has(exprText) || DOWNLOAD_FUNCTIONS.has(methodName)) {
-        findings.push({
-          category: 'install-scripts',
-          severity: 'critical',
-          location: getLocation(sourceFile, call.getStart(), relPath),
-          description: `Download-and-execute pattern: ${exprText}() with subsequent code execution in same file`,
-          codeSnippet: truncate(call.getText().trim(), 120),
-          confidence: 0.9,
-        });
-        break; // report once per file
+        if (DOWNLOAD_FUNCTIONS.has(exprText) || DOWNLOAD_FUNCTIONS.has(methodName)) {
+          findings.push({
+            category: 'install-scripts',
+            severity: isInstallScript ? 'critical' : 'low',
+            location: getLocation(sourceFile, call.getStart(), relPath),
+            description: isInstallScript
+              ? `Download-and-execute pattern: ${exprText}() with subsequent code execution in install script`
+              : `File has both network fetch and code execution (common in tools/servers)`,
+            codeSnippet: truncate(call.getText().trim(), 120),
+            confidence: isInstallScript ? 0.9 : 0.3,
+          });
+          break; // report once per file
+        }
       }
     }
   }
@@ -190,11 +230,13 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
   if (hasDownload.size > 0 && hasCreateWriteStream && hasExecute.size > 0) {
     findings.push({
       category: 'install-scripts',
-      severity: 'critical',
+      severity: isInstallScript ? 'critical' : 'medium',
       location: { file: relPath, line: 1, column: 1 },
-      description: 'File downloads content to disk and executes it (download-write-execute pattern)',
+      description: isInstallScript
+        ? 'Install script downloads content to disk and executes it (download-write-execute pattern)'
+        : 'File has download, write, and execute calls (common in build tools)',
       codeSnippet: '',
-      confidence: 0.85,
+      confidence: isInstallScript ? 0.85 : 0.3,
     });
   }
 

--- a/packages/scanner/src/detectors/network-access.ts
+++ b/packages/scanner/src/detectors/network-access.ts
@@ -16,17 +16,17 @@ const NETWORK_CALL_PATTERNS = new Set([
   'delete',
 ]);
 
+/**
+ * Outbound network calls — these SEND data to remote hosts.
+ * These are relevant for exfiltration detection when combined with fs access.
+ */
 const QUALIFIED_NETWORK_CALLS = new Set([
   'http.request',
   'http.get',
   'https.request',
   'https.get',
-  'http.createServer',
-  'https.createServer',
   'net.createConnection',
   'net.connect',
-  'net.createServer',
-  'dgram.createSocket',
   'axios.get',
   'axios.post',
   'axios.put',
@@ -38,6 +38,17 @@ const QUALIFIED_NETWORK_CALLS = new Set([
   'got.put',
   'got.patch',
   'got.delete',
+]);
+
+/**
+ * Server-side listeners — these ACCEPT incoming connections.
+ * Not exfiltration vectors. Flagged at lower severity as informational.
+ */
+const SERVER_LISTENER_CALLS = new Set([
+  'http.createServer',
+  'https.createServer',
+  'net.createServer',
+  'dgram.createSocket',
 ]);
 
 const SAFE_URL_HOSTS = new Set([
@@ -113,6 +124,20 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
   for (const call of sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)) {
     const exprText = call.getExpression().getText();
 
+    // Server listeners (http.createServer, net.createServer) accept incoming
+    // connections — they are NOT outbound exfiltration vectors.
+    if (SERVER_LISTENER_CALLS.has(exprText)) {
+      findings.push({
+        category: 'network-access',
+        severity: 'low',
+        location: getLocation(sourceFile, call.getStart(), relPath),
+        description: `Creates local server: ${exprText}()`,
+        codeSnippet: truncate(call.getText().trim(), 120),
+        confidence: 1.0,
+      });
+      continue;
+    }
+
     let isNetworkCall = false;
     let description = '';
 
@@ -129,14 +154,17 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
 
     if (!isNetworkCall) continue;
 
-    // Check if it contains a URL with external host
+    // Check if the URL targets a safe/local host
     let hasExternalUrl = false;
+    let targetsLocalhost = false;
     for (const arg of call.getArguments()) {
       const argText = arg.getText();
       const urlMatch = argText.match(/https?:\/\/([^/'"\s:]+)/);
       if (urlMatch) {
         const host = urlMatch[1]!;
-        if (!SAFE_URL_HOSTS.has(host)) {
+        if (SAFE_URL_HOSTS.has(host) || /^127\.\d+\.\d+\.\d+$/.test(host) || host === '::1') {
+          targetsLocalhost = true;
+        } else {
           hasExternalUrl = true;
         }
       }
@@ -145,12 +173,17 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
     // Determine severity based on what we can observe at the detector level.
     // Co-occurrence of fs + network is a signal, but NOT confirmed exfiltration —
     // the taint tracker handles actual data-flow analysis with proper context.
-    // MCP servers and CLI tools legitimately need both fs and network access.
-    let severity: Severity = hasExternalUrl ? 'high' : 'medium';
-
-    if (hasFsImport) {
-      severity = severity === 'medium' ? 'medium' : 'high';
-      description += ' (co-occurs with filesystem access)';
+    // Localhost/loopback calls are not exfiltration regardless of fs access.
+    let severity: Severity;
+    if (targetsLocalhost && !hasExternalUrl) {
+      severity = 'low';
+      description += ' (targets localhost)';
+    } else {
+      severity = hasExternalUrl ? 'high' : 'medium';
+      if (hasFsImport && !targetsLocalhost) {
+        severity = severity === 'medium' ? 'medium' : 'high';
+        description += ' (co-occurs with filesystem access)';
+      }
     }
 
     findings.push({

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -248,8 +248,24 @@ const TEST_FILE_PATTERNS = [
 ];
 
 /**
+ * Security documentation file patterns.
+ * These files describe threats a project defends against — phrases like
+ * "steal credentials" or "ignore previous instructions" are DEFENSIVE
+ * documentation, not attack instructions.
+ */
+const SECURITY_DOC_PATTERNS = [
+  /^SECURITY\.md$/i,
+  /^SECURITY\.txt$/i,
+  /^THREAT[_-]?MODEL/i,
+  /^RESPONSIBLE[_-]?DISCLOSURE/i,
+  /^VULNERABILITY/i,
+  /^PENTEST/i,
+];
+
+/**
  * Returns true if a relative file path falls inside a recognised
- * test / fixture / golden directory, or matches a test file name pattern.
+ * test / fixture / golden directory, matches a test file name pattern,
+ * or is a security documentation file (threat models, disclosure policies).
  */
 export function isTestFixturePath(relPath: string): boolean {
   const normalized = relPath.replace(/\\/g, '/');
@@ -271,7 +287,12 @@ export function isTestFixturePath(relPath: string): boolean {
 
   // Check the file name itself for test patterns
   const fileName = segments[segments.length - 1] ?? '';
-  return TEST_FILE_PATTERNS.some(re => re.test(fileName));
+  if (TEST_FILE_PATTERNS.some(re => re.test(fileName))) return true;
+
+  // Security documentation files — describe attacks the project defends against
+  if (SECURITY_DOC_PATTERNS.some(re => re.test(fileName))) return true;
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Separate server listeners from outbound calls** — `http.createServer()` is not exfiltration
- **Localhost/loopback calls excluded** from co-occurrence and taint flow sinks
- **Install-scripts detector scoped** to actual install scripts — regular source files get low severity
- **SSRF guard detection** — security validation code near fetch+exec suppresses the finding
- **Security docs** (`SECURITY.md`, `THREAT_MODEL.md`) get reduced-confidence treatment
- Bump CLI to v0.3.1

Addresses community feedback from [#5](https://github.com/OyadotAI/safeskill/issues/5) (TPEmist/pop-pay).

## Changes

| False Positive | Fix |
|---|---|
| `http.createServer()` flagged as exfiltration | Separated into `SERVER_LISTENER_CALLS` set, severity `low` |
| `fetch('http://localhost:9222')` + fs = critical | Localhost/loopback detection skips co-occurrence and taint sinks |
| `fetch()` + `exec()` in MCP tool file = "download-and-execute" | Critical only in install scripts, low/skipped in regular source |
| SSRF guard (`isPrivateIP()`) flagged as the vulnerability | Security guard pattern detection suppresses finding |
| `SECURITY.md` "steal credentials" = critical prompt injection | Security doc files get reduced-confidence like test fixtures |

## Files changed
- `packages/scanner/src/detectors/network-access.ts` — server listeners, localhost detection
- `packages/scanner/src/detectors/install-scripts.ts` — scoped detection, SSRF guard check
- `packages/scanner/src/analyzers/taint-tracker.ts` — skip server listeners and localhost sinks
- `packages/shared/src/constants.ts` — security doc patterns in `isTestFixturePath`
- `packages/cli/package.json` — version bump to 0.3.1

## Test plan
- [ ] Scan `pop-pay` npm package — verify no false critical findings from createServer, localhost fetch, or SSRF guards
- [ ] Scan a project with `SECURITY.md` containing threat model language — verify reduced confidence
- [ ] Scan a project with actual malicious install scripts — verify still flagged as critical
- [ ] Scan a project with `fetch()` to external URLs + fs — verify still flagged appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)