### PR TITLE
Fix scanner hang on local checkouts and five false-positive rules

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillsafe",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "description": "SafeSkill CLI — scan AI tool skills for security risks and prompt injection",
   "author": "SafeSkill",

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -39,7 +39,19 @@ export function registerScanCommand(program: Command): void {
     .option('--skip-deps', 'Skip dependency analysis (faster)')
     .option('--no-color', 'Disable colored output')
     .option('--share', 'Upload the scan result and get a shareable URL')
-    .action(async (pkg: string, options: { json?: boolean; skipDeps?: boolean; share?: boolean }) => {
+    .option(
+      '--exclude <glob...>',
+      'Extra glob patterns to exclude from file discovery (repeatable). A .safeskillignore file in the target is also honored.',
+    )
+    .action(async (
+      pkg: string,
+      options: {
+        json?: boolean;
+        skipDeps?: boolean;
+        share?: boolean;
+        exclude?: string[];
+      },
+    ) => {
       const spinner = ora({
         text: `Resolving ${chalk.cyan(pkg)}...`,
         color: 'cyan',
@@ -49,13 +61,14 @@ export function registerScanCommand(program: Command): void {
         // Resolve package to a directory
         const { dir, packageName, packageVersion, cleanup } = await resolvePackage(pkg);
 
-        spinner.text = `Scanning ${chalk.cyan(packageName)}...`;
+        spinner.text = `Scanning ${chalk.cyan(packageName)} (this may take a few seconds on large repos)...`;
 
         const result = await scan({
           dir,
           packageName,
           packageVersion: packageVersion ?? undefined,
           skipDeps: options.skipDeps,
+          excludePaths: options.exclude,
         });
 
         spinner.stop();

--- a/packages/scanner/src/analyzers/ast-analyzer.ts
+++ b/packages/scanner/src/analyzers/ast-analyzer.ts
@@ -1,9 +1,40 @@
 import { Project, SyntaxKind, type SourceFile } from 'ts-morph';
 import path from 'path';
+import { globby } from 'globby';
 import type { CodeFinding, DetectorCategory, SourceLocation } from '@safeskill/shared';
 import { isTestFixturePath, TEST_FIXTURE_CONFIDENCE_FACTOR } from '@safeskill/shared';
 import { ALL_DETECTORS } from '../detectors/index.js';
 import { truncate } from '../utils.js';
+
+// Hard cap on files handed to ts-morph. On a local checkout with a full
+// node_modules, the glob can match tens of thousands of files and pin a core
+// indefinitely. node_modules is already ignored; this cap is a safety net for
+// monorepos / generated code sprawl.
+const MAX_AST_FILES = 5000;
+
+// Default ignore patterns. `dist/`, `build/`, and `out/` are deliberately NOT
+// listed — we decide at scan time whether to skip them. For local checkouts
+// that have a sibling `src/`, those directories are generated and skipping
+// them avoids duplicate findings. For published npm tarballs that only ship
+// compiled output, those directories ARE the code we need to analyse;
+// skipping them produces the `filesScanned: 0` bug.
+const BASE_IGNORES = [
+  'node_modules/**',
+  '**/node_modules/**',
+  '.next/**',
+  '.turbo/**',
+  '.cache/**',
+  'coverage/**',
+  '.git/**',
+  '**/*.d.ts',
+  '**/*.test.*',
+  '**/*.spec.*',
+  '**/*.min.js',
+  '**/*.min.mjs',
+  '**/*.bundle.js',
+];
+
+const GENERATED_DIRS = ['dist/**', 'build/**', 'out/**'];
 
 // ---------------------------------------------------------------------------
 // Public result types
@@ -312,6 +343,7 @@ function analyzeSourceFile(
 export async function analyzeAST(
   dir: string,
   flaggedFiles: Set<string>,
+  extraIgnores: string[] = [],
 ): Promise<ASTResult> {
   const project = new Project({
     compilerOptions: {
@@ -325,39 +357,44 @@ export async function analyzeAST(
     skipFileDependencyResolution: true,
   });
 
-  // Add source files — prioritize flagged files but scan all code files
-  const globPatterns = [
-    path.join(dir, '**/*.ts'),
-    path.join(dir, '**/*.js'),
-    path.join(dir, '**/*.mjs'),
-    path.join(dir, '**/*.cjs'),
-  ];
+  // Enumerate files with globby FIRST so node_modules and other ignored trees
+  // are never walked by ts-morph. Passing the ignore patterns to
+  // addSourceFilesAtPaths was insufficient — ts-morph loaded everything first,
+  // which pinned a core on any checkout with a full node_modules.
+  const globPatterns = ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx', '**/*.mjs', '**/*.cjs'];
 
-  const ignorePatterns = [
-    path.join(dir, 'node_modules/**'),
-    path.join(dir, 'dist/**'),
-    path.join(dir, '.git/**'),
-    path.join(dir, '**/*.d.ts'),
-    path.join(dir, '**/*.test.*'),
-    path.join(dir, '**/*.spec.*'),
-  ];
+  // First pass: ignore generated dirs. If the source tree is the generated
+  // output (published tarballs that ship dist/ only), this returns nothing —
+  // fall back to including generated dirs so we still scan the shipped code.
+  let relFiles = await globby(globPatterns, {
+    cwd: dir,
+    ignore: [...BASE_IGNORES, ...GENERATED_DIRS, ...extraIgnores],
+    absolute: false,
+    followSymbolicLinks: false,
+    gitignore: false,
+  });
 
-  project.addSourceFilesAtPaths(
-    globPatterns.map((p) => `${p}`),
-  );
+  if (relFiles.length === 0) {
+    relFiles = await globby(globPatterns, {
+      cwd: dir,
+      ignore: [...BASE_IGNORES, ...extraIgnores],
+      absolute: false,
+      followSymbolicLinks: false,
+      gitignore: false,
+    });
+  }
 
-  // Remove files matching ignore patterns
-  for (const sf of project.getSourceFiles()) {
-    const filePath = sf.getFilePath();
-    if (ignorePatterns.some((pattern) => {
-      // Simple glob matching: convert ** to regex
-      const regexStr = pattern
-        .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-        .replace(/\*\*/g, '.*')
-        .replace(/\*/g, '[^/]*');
-      return new RegExp(`^${regexStr}$`).test(filePath);
-    })) {
-      project.removeSourceFile(sf);
+  // Apply hard cap to prevent runaway parsing on huge repos. Deterministic
+  // ordering so the cap truncation is stable across runs.
+  relFiles.sort();
+  const limited = relFiles.slice(0, MAX_AST_FILES);
+
+  for (const rel of limited) {
+    const abs = path.join(dir, rel);
+    try {
+      project.addSourceFileAtPath(abs);
+    } catch {
+      // Unreadable or malformed file — skip.
     }
   }
 

--- a/packages/scanner/src/analyzers/content-scanner.ts
+++ b/packages/scanner/src/analyzers/content-scanner.ts
@@ -16,7 +16,10 @@ export interface ContentFile {
  * Discovers all content files that need prompt injection scanning.
  * Also extracts long string literals from code that look like prompts.
  */
-export async function discoverContent(dir: string): Promise<ContentFile[]> {
+export async function discoverContent(
+  dir: string,
+  extraIgnores: string[] = [],
+): Promise<ContentFile[]> {
   const results: ContentFile[] = [];
 
   // Find all content files
@@ -24,14 +27,20 @@ export async function discoverContent(dir: string): Promise<ContentFile[]> {
   const files = await globby(contentGlobs, {
     cwd: dir,
     ignore: [
-      'node_modules/**', 'dist/**', '.git/**',
+      'node_modules/**', '**/node_modules/**',
+      'dist/**', 'build/**', 'out/**',
+      '.next/**', '.turbo/**', '.cache/**',
+      'coverage/**', '.git/**',
       'CHANGELOG.md', 'CHANGELOG/**',
       // License files contain standard legal text — not security-relevant content
       'LICENSE', 'LICENSE.*', 'LICENCE', 'LICENCE.*',
       'LICENSES/**', 'LICENCES/**',
       '**/LICENSE', '**/LICENSE.*',
+      ...extraIgnores,
     ],
     absolute: false,
+    followSymbolicLinks: false,
+    gitignore: false,
   });
 
   const prioritySet = new Set(PRIORITY_CONTENT_FILES.map(f => f.toLowerCase()));
@@ -63,8 +72,17 @@ export async function discoverContent(dir: string): Promise<ContentFile[]> {
   // Extract prompt-like strings from code files
   const codeFiles = await globby(['**/*.{ts,js,mjs,cjs}'], {
     cwd: dir,
-    ignore: ['node_modules/**', 'dist/**', '.git/**', '**/*.d.ts'],
+    ignore: [
+      'node_modules/**', '**/node_modules/**',
+      'dist/**', 'build/**', 'out/**',
+      '.next/**', '.turbo/**', '.cache/**',
+      'coverage/**', '.git/**',
+      '**/*.d.ts',
+      ...extraIgnores,
+    ],
     absolute: false,
+    followSymbolicLinks: false,
+    gitignore: false,
   });
 
   await Promise.all(

--- a/packages/scanner/src/analyzers/ignore-file.ts
+++ b/packages/scanner/src/analyzers/ignore-file.ts
@@ -30,6 +30,9 @@ export interface IgnoreRules {
   taintPatterns: Array<{ source: RegExp; sink: RegExp }>;
   /** File path patterns */
   filePatterns: RegExp[];
+  /** Raw file globs (as written) — passed to file-discovery layers so we
+   * never read or parse these paths in the first place. */
+  fileGlobs: string[];
 }
 
 function globToRegex(glob: string): RegExp {
@@ -47,6 +50,7 @@ export function parseIgnoreRules(content: string): IgnoreRules {
     categoryPatterns: [],
     taintPatterns: [],
     filePatterns: [],
+    fileGlobs: [],
   };
 
   for (const rawLine of content.split('\n')) {
@@ -55,7 +59,10 @@ export function parseIgnoreRules(content: string): IgnoreRules {
 
     if (line.startsWith('file:')) {
       const glob = line.slice(5).trim();
-      if (glob) rules.filePatterns.push(globToRegex(glob));
+      if (glob) {
+        rules.filePatterns.push(globToRegex(glob));
+        rules.fileGlobs.push(glob);
+      }
     } else if (line.startsWith('taint:')) {
       const spec = line.slice(6).trim();
       const arrowIdx = spec.indexOf('->');

--- a/packages/scanner/src/analyzers/manifest-analyzer.ts
+++ b/packages/scanner/src/analyzers/manifest-analyzer.ts
@@ -262,16 +262,25 @@ function detectPackageType(pkg: Record<string, unknown>, deps: Record<string, st
   const hasBin = !!pkg.bin;
   const allText = `${name} ${desc} ${keywords.join(' ')}`;
 
+  // MCP-server indicators come FIRST. Most MCP servers ship a `bin` entry
+  // so clients can `npx` them, which previously caused them to be classified
+  // as CLI tools and have their code scan short-circuited in scoring.
+  // Check the strongest signal — actually depending on the MCP SDK — before
+  // any keyword heuristics so tools that merely mention "mcp" in their
+  // description (e.g. a tool that scans MCP servers) aren't miscategorized.
+  if (deps['@modelcontextprotocol/sdk'] || deps['mcp-framework']) return 'mcp-server';
+  if (keywords.some(k => k === 'mcp-server' || k === 'mcp_server' || k === 'modelcontextprotocol')) {
+    return 'mcp-server';
+  }
+  if (/\bmcp\s+server\b/.test(allText) || /-mcp($|-)/.test(name) || /^mcp-/.test(name)) {
+    return 'mcp-server';
+  }
+
   // CLI tool indicators
   if (hasBin) return 'cli-tool';
   if (keywords.some(k => ['cli', 'command-line', 'terminal', 'shell', 'devtool', 'dev-tool'].includes(k))) return 'cli-tool';
   if (allText.includes('cli') && (allText.includes('tool') || allText.includes('command'))) return 'cli-tool';
   if (deps['commander'] || deps['yargs'] || deps['meow'] || deps['cac'] || deps['clipanion'] || deps['oclif']) return 'cli-tool';
-
-  // MCP server indicators
-  if (allText.includes('mcp') && allText.includes('server')) return 'mcp-server';
-  if (keywords.some(k => k.includes('mcp'))) return 'mcp-server';
-  if (deps['@modelcontextprotocol/sdk'] || deps['mcp-framework']) return 'mcp-server';
 
   // Skill indicators
   if (keywords.some(k => ['claude-skill', 'claude-code', 'openclaw', 'ai-skill'].includes(k))) return 'skill';

--- a/packages/scanner/src/analyzers/pattern-matcher.ts
+++ b/packages/scanner/src/analyzers/pattern-matcher.ts
@@ -19,7 +19,11 @@ const PATTERNS: PatternRule[] = [
   { pattern: /from\s+['"](?:node:)?fs(?:\/promises)?['"]/g, category: 'filesystem-access', severity: 'medium', description: 'Imports filesystem module', confidence: 1.0 },
   { pattern: /require\s*\(\s*['"]fs-extra['"]\s*\)/g, category: 'filesystem-access', severity: 'medium', description: 'Imports fs-extra', confidence: 1.0 },
   { pattern: /\.(readFileSync|readFile|writeFileSync|writeFile|unlinkSync|unlink|rmdirSync|rmdir|rmSync)\s*\(/g, category: 'filesystem-access', severity: 'high', description: 'Direct filesystem operation', confidence: 0.9 },
-  { pattern: /(?:~\/\.ssh|~\/\.aws|~\/\.env|~\/\.gnupg|~\/\.npmrc|~\/\.docker|~\/\.kube|\/etc\/passwd|\/etc\/shadow)/g, category: 'filesystem-access', severity: 'critical', description: 'Accesses sensitive system path', confidence: 0.95 },
+  // Sensitive path regex — a bare string literal mentioning a sensitive path is
+  // not by itself "access". Severity is gated later: kept at high only when the
+  // same file also contains fs imports / fs operations, otherwise demoted.
+  // Detector `filesystem-access` handles real fs calls at the AST level.
+  { pattern: /(?:~\/\.ssh|~\/\.aws|~\/\.env|~\/\.gnupg|~\/\.npmrc|~\/\.docker|~\/\.kube|\/etc\/passwd|\/etc\/shadow)/g, category: 'filesystem-access', severity: 'high', description: 'References sensitive system path', confidence: 0.7 },
   { pattern: /(?:homedir|userInfo)\s*\(\s*\)/g, category: 'filesystem-access', severity: 'medium', description: 'Accesses user home directory info', confidence: 0.8 },
 
   // Network access
@@ -65,12 +69,56 @@ export interface PatternMatchResult {
   flaggedFiles: Set<string>;
 }
 
-export async function analyzePatterns(dir: string): Promise<PatternMatchResult> {
-  const files = await globby(['**/*.{ts,js,mjs,cjs,tsx,jsx}'], {
+// UI/frontend file extensions that cannot perform filesystem access at runtime.
+// Sensitive-path string literals in these files are doc/help text, not exfil vectors.
+const UI_FILE_EXTS = new Set(['.tsx', '.jsx', '.vue', '.svelte']);
+
+function isUiFile(relPath: string): boolean {
+  const ext = relPath.slice(relPath.lastIndexOf('.'));
+  return UI_FILE_EXTS.has(ext);
+}
+
+export async function analyzePatterns(
+  dir: string,
+  extraIgnores: string[] = [],
+): Promise<PatternMatchResult> {
+  const globPatterns = ['**/*.{ts,js,mjs,cjs,tsx,jsx}'];
+  const baseIgnores = [
+    'node_modules/**',
+    '**/node_modules/**',
+    '.next/**',
+    '.turbo/**',
+    '.cache/**',
+    'coverage/**',
+    '.git/**',
+    '**/*.d.ts',
+    '**/*.test.*',
+    '**/*.spec.*',
+    '**/*.min.js',
+    '**/*.min.mjs',
+    '**/*.bundle.js',
+    ...extraIgnores,
+  ];
+  const generatedDirs = ['dist/**', 'build/**', 'out/**'];
+
+  // First pass skips generated output; fall back to scanning it if that's
+  // all the tarball shipped (matches ast-analyzer behavior).
+  let files = await globby(globPatterns, {
     cwd: dir,
-    ignore: ['node_modules/**', 'dist/**', '.git/**', '**/*.d.ts', '**/*.test.*', '**/*.spec.*'],
+    ignore: [...baseIgnores, ...generatedDirs],
     absolute: false,
+    followSymbolicLinks: false,
+    gitignore: false,
   });
+  if (files.length === 0) {
+    files = await globby(globPatterns, {
+      cwd: dir,
+      ignore: baseIgnores,
+      absolute: false,
+      followSymbolicLinks: false,
+      gitignore: false,
+    });
+  }
 
   const findings: CodeFinding[] = [];
   const flaggedFiles = new Set<string>();
@@ -86,8 +134,21 @@ export async function analyzePatterns(dir: string): Promise<PatternMatchResult> 
       }
 
       const isFixture = isTestFixturePath(relPath);
+      const ui = isUiFile(relPath);
+      // A file "does fs" if it imports an fs module or uses a known fs API.
+      // When false, a sensitive-path string literal is almost always docs/help
+      // text, not a read/write operation.
+      const hasFsContext =
+        /require\s*\(\s*['"](?:node:)?fs(?:\/promises)?['"]\s*\)/.test(content) ||
+        /from\s+['"](?:node:)?fs(?:\/promises)?['"]/.test(content) ||
+        /\b(?:readFileSync|readFile|writeFileSync|writeFile|unlink|appendFile|createReadStream|createWriteStream)\s*\(/.test(content);
 
       for (const rule of PATTERNS) {
+        // Sensitive-path rule: skip entirely for UI files (browser, no fs)
+        // and for files with no fs context (docs/strings, not access).
+        const isSensitivePathRule = rule.description === 'References sensitive system path';
+        if (isSensitivePathRule && (ui || !hasFsContext)) continue;
+
         const regex = new RegExp(rule.pattern.source, rule.pattern.flags);
         let match: RegExpExecArray | null;
 

--- a/packages/scanner/src/analyzers/taint-tracker.ts
+++ b/packages/scanner/src/analyzers/taint-tracker.ts
@@ -219,15 +219,30 @@ function findSources(file: FileAnalysis): SourceInfo[] {
 }
 
 const LOCALHOST_PATTERNS = /\b(localhost|127\.\d+\.\d+\.\d+|0\.0\.0\.0|::1)\b/;
+const HOSTNAME_PROP = /\b(?:hostname|host)\s*:\s*['"`]([^'"`]+)['"`]/;
 
 /**
- * Returns true if all URL arguments in a call target localhost/loopback.
- * Local network calls are not exfiltration sinks.
+ * Returns true if every host target we can see in the call's arguments is
+ * localhost/loopback. Accepts both URL strings ("http://127.0.0.1/…") and
+ * options objects ({ hostname: "127.0.0.1", port, path }) used by
+ * http.request / https.request.
  */
 function targetsLocalhost(args: string[]): boolean {
-  const urlArgs = args.filter(a => /https?:\/\//.test(a) || LOCALHOST_PATTERNS.test(a));
-  if (urlArgs.length === 0) return false;
-  return urlArgs.every(a => LOCALHOST_PATTERNS.test(a));
+  let saw = false;
+  let allLocal = true;
+  for (const a of args) {
+    if (/https?:\/\//.test(a)) {
+      saw = true;
+      if (!LOCALHOST_PATTERNS.test(a)) allLocal = false;
+    }
+    const hostProp = a.match(HOSTNAME_PROP);
+    if (hostProp) {
+      saw = true;
+      const host = hostProp[1]!.toLowerCase();
+      if (!LOCALHOST_PATTERNS.test(host) && host !== 'localhost') allLocal = false;
+    }
+  }
+  return saw && allLocal;
 }
 
 /**

--- a/packages/scanner/src/detectors/dynamic-require.ts
+++ b/packages/scanner/src/detectors/dynamic-require.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type SourceFile } from 'ts-morph';
+import { Node, SyntaxKind, type SourceFile } from 'ts-morph';
 import type { CodeFinding } from '@safeskill/shared';
 import { truncate } from '../utils.js';
 
@@ -7,11 +7,29 @@ function getLocation(sourceFile: SourceFile, pos: number, relPath: string) {
   return { file: relPath, line, column };
 }
 
-function isLiteralArgument(argKind: SyntaxKind): boolean {
-  return (
-    argKind === SyntaxKind.StringLiteral ||
-    argKind === SyntaxKind.NoSubstitutionTemplateLiteral
-  );
+/**
+ * Returns true when `arg` is (or wraps) a compile-time string literal that
+ * can be resolved without executing user code. Parenthesized expressions,
+ * `as const` assertions, satisfies clauses, and non-null assertions all
+ * preserve the underlying literal and should not be flagged as dynamic.
+ */
+function isLiteralArgument(arg: Node): boolean {
+  const kind = arg.getKind();
+  if (kind === SyntaxKind.StringLiteral || kind === SyntaxKind.NoSubstitutionTemplateLiteral) {
+    return true;
+  }
+  if (
+    kind === SyntaxKind.ParenthesizedExpression ||
+    kind === SyntaxKind.AsExpression ||
+    kind === SyntaxKind.TypeAssertionExpression ||
+    kind === SyntaxKind.SatisfiesExpression ||
+    kind === SyntaxKind.NonNullExpression
+  ) {
+    const inner =
+      (arg as unknown as { getExpression?: () => Node }).getExpression?.();
+    return inner ? isLiteralArgument(inner) : false;
+  }
+  return false;
 }
 
 export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
@@ -27,7 +45,7 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
       if (args.length === 0) continue;
 
       const firstArg = args[0]!;
-      if (!isLiteralArgument(firstArg.getKind())) {
+      if (!isLiteralArgument(firstArg)) {
         findings.push({
           category: 'dynamic-require',
           severity: 'high',
@@ -45,7 +63,7 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
       if (args.length === 0) continue;
 
       const firstArg = args[0]!;
-      if (!isLiteralArgument(firstArg.getKind())) {
+      if (!isLiteralArgument(firstArg)) {
         findings.push({
           category: 'dynamic-require',
           severity: 'high',
@@ -63,7 +81,7 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
       if (args.length === 0) continue;
 
       const firstArg = args[0]!;
-      if (!isLiteralArgument(firstArg.getKind())) {
+      if (!isLiteralArgument(firstArg)) {
         findings.push({
           category: 'dynamic-require',
           severity: 'high',
@@ -88,7 +106,7 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
       if (args.length === 0) continue;
 
       const firstArg = args[0]!;
-      if (!isLiteralArgument(firstArg.getKind())) {
+      if (!isLiteralArgument(firstArg)) {
         findings.push({
           category: 'dynamic-require',
           severity: 'high',

--- a/packages/scanner/src/detectors/network-access.ts
+++ b/packages/scanner/src/detectors/network-access.ts
@@ -154,7 +154,9 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
 
     if (!isNetworkCall) continue;
 
-    // Check if the URL targets a safe/local host
+    // Check if the URL targets a safe/local host. Hostnames can appear in two
+    // shapes: a string URL ("http://example.com/foo") or an options object
+    // ({ hostname: "127.0.0.1", port, path, ... }) used by http.request.
     let hasExternalUrl = false;
     let targetsLocalhost = false;
     for (const arg of call.getArguments()) {
@@ -163,6 +165,22 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
       if (urlMatch) {
         const host = urlMatch[1]!;
         if (SAFE_URL_HOSTS.has(host) || /^127\.\d+\.\d+\.\d+$/.test(host) || host === '::1') {
+          targetsLocalhost = true;
+        } else {
+          hasExternalUrl = true;
+        }
+      }
+      // Options-object form: { hostname: "...", host: "..." }
+      const hostnameMatch = argText.match(/\b(?:hostname|host)\s*:\s*['"`]([^'"`]+)['"`]/);
+      if (hostnameMatch) {
+        const host = hostnameMatch[1]!.toLowerCase();
+        if (
+          SAFE_URL_HOSTS.has(host) ||
+          /^127\.\d+\.\d+\.\d+$/.test(host) ||
+          host === '::1' ||
+          host === 'localhost' ||
+          host === '0.0.0.0'
+        ) {
           targetsLocalhost = true;
         } else {
           hasExternalUrl = true;

--- a/packages/scanner/src/detectors/obfuscation.ts
+++ b/packages/scanner/src/detectors/obfuscation.ts
@@ -133,7 +133,10 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
     }
   }
 
-  // Detect very long single-line expressions (>500 chars, likely minified/obfuscated)
+  // Detect very long single-line expressions (likely minified/obfuscated).
+  // Heuristic: minified code is code — packed with operators, semicolons, and
+  // identifier punctuation. A long line that is predominantly inside a single
+  // string literal is a long prompt or help text, not obfuscation.
   const fullText = sourceFile.getFullText();
   const lines = fullText.split('\n');
   for (let i = 0; i < lines.length; i++) {
@@ -144,22 +147,38 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
     if (trimmed.startsWith('import ') || trimmed.startsWith('require(')) continue;
     if (trimmed.startsWith('export ')) continue;
 
-    if (line.length > 500) {
-      // Skip long string literal assignments — system prompts, templates, etc.
-      // These are common in constants files and are not obfuscation.
-      if (/^\s*(?:const|let|var|export\s+(?:const|let|var))\s+\w+\s*=\s*['"`]/.test(trimmed)) continue;
-      // Also skip lines that are predominantly a string (array of strings, object values)
-      if (/^\s*['"`]/.test(trimmed) || /^\s*\[?\s*['"`]/.test(trimmed)) continue;
+    // Raise the minimum length — 500 fires on long prompts and MCP tool
+    // descriptions; 800 avoids most prose while still catching packed code.
+    if (line.length <= 800) continue;
 
-      findings.push({
-        category: 'obfuscation',
-        severity: 'critical',
-        location: { file: relPath, line: i + 1, column: 1 },
-        description: `Very long single-line expression (${line.length} chars) — possibly minified or obfuscated code`,
-        codeSnippet: truncate(trimmed, 120),
-        confidence: 0.75,
-      });
-    }
+    // Skip long string literal assignments — system prompts, templates, etc.
+    if (/^\s*(?:const|let|var|export\s+(?:const|let|var))\s+\w+\s*(?::\s*[\w<>,|\s]+\s*)?=\s*['"`]/.test(trimmed)) continue;
+    // Skip object property / argument values where the RHS is a string.
+    // Covers MCP tool definitions like  `description: 'Retrieve a symbol...'`
+    // and inline return statements like `return \`<long prompt>\`;`.
+    if (/^\s*(?:['"][\w$-]+['"]|\w+)\s*:\s*['"`]/.test(trimmed)) continue;
+    if (/^\s*return\s+['"`]/.test(trimmed)) continue;
+    // Lines that start with a string/array/template literal.
+    if (/^\s*['"`]/.test(trimmed) || /^\s*\[?\s*['"`]/.test(trimmed)) continue;
+
+    // Measure how much of the line is inside string/template literals. If most
+    // characters are inside quotes, this is prose, not code.
+    const nonStringLen = measureNonStringLength(line);
+    if (nonStringLen < line.length * 0.3) continue;
+
+    // Require code-like density: multiple operators / semicolons / punctuation.
+    // A true minified line hits these hundreds of times; prose hits them few.
+    const codePunct = (line.match(/[;{}()=+\-*/&|<>!?:,]/g) ?? []).length;
+    if (codePunct < 20) continue;
+
+    findings.push({
+      category: 'obfuscation',
+      severity: 'critical',
+      location: { file: relPath, line: i + 1, column: 1 },
+      description: `Very long single-line expression (${line.length} chars) — possibly minified or obfuscated code`,
+      codeSnippet: truncate(trimmed, 120),
+      confidence: 0.75,
+    });
   }
 
   // Detect eval with string concatenation
@@ -192,17 +211,60 @@ export function detect(sourceFile: SourceFile, relPath: string): CodeFinding[] {
   for (const literal of sourceFile.getDescendantsOfKind(SyntaxKind.StringLiteral)) {
     const rawText = literal.getText();
     const unicodeMatches = rawText.match(unicodeIdentifierPattern);
-    if (unicodeMatches && unicodeMatches.length > 3) {
-      findings.push({
-        category: 'obfuscation',
-        severity: 'critical',
-        location: getLocation(sourceFile, literal.getStart(), relPath),
-        description: `Unicode-escaped string with ${unicodeMatches.length} escape sequences`,
-        codeSnippet: truncate(rawText, 120),
-        confidence: 0.85,
-      });
-    }
+    if (!unicodeMatches || unicodeMatches.length <= 3) continue;
+
+    // Only flag when escapes decode to printable ASCII — the classic
+    // identifier-obfuscation shape. Box-drawing banners (U+2500–U+259F),
+    // bullets (U+2022), and other non-ASCII display characters are legitimate.
+    const ascii = countAsciiPrintableEscapes(unicodeMatches);
+    if (ascii <= 3) continue;
+
+    findings.push({
+      category: 'obfuscation',
+      severity: 'critical',
+      location: getLocation(sourceFile, literal.getStart(), relPath),
+      description: `Unicode-escaped string with ${ascii} ASCII-identifier escapes (string obfuscation)`,
+      codeSnippet: truncate(rawText, 120),
+      confidence: 0.85,
+    });
   }
 
   return findings;
+}
+
+/**
+ * Counts how many chars of `line` lie outside single/double/backtick string
+ * literals. Rough lexer — enough to distinguish a 900-char template-literal
+ * prompt from a 900-char minified statement.
+ */
+function measureNonStringLength(line: string): number {
+  let inStr: '"' | "'" | '`' | null = null;
+  let escape = false;
+  let nonStr = 0;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i]!;
+    if (inStr) {
+      if (escape) { escape = false; continue; }
+      if (c === '\\') { escape = true; continue; }
+      if (c === inStr) { inStr = null; }
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') { inStr = c; continue; }
+    nonStr++;
+  }
+  return nonStr;
+}
+
+/**
+ * Counts \uXXXX escapes whose code point is a printable ASCII character
+ * (U+0020..U+007E). These are the shapes used to obfuscate identifiers like
+ * "process" or "require".
+ */
+function countAsciiPrintableEscapes(matches: RegExpMatchArray): number {
+  let n = 0;
+  for (const m of matches) {
+    const cp = parseInt(m.slice(2), 16);
+    if (cp >= 0x20 && cp <= 0x7e) n++;
+  }
+  return n;
 }

--- a/packages/scanner/src/index.ts
+++ b/packages/scanner/src/index.ts
@@ -21,23 +21,34 @@ export interface ScanOptions {
   packageVersion?: string;
   /** Skip dependency analysis (faster) */
   skipDeps?: boolean;
+  /** Extra glob patterns to exclude from file discovery (in addition to
+   *  the built-in defaults and anything declared in .safeskillignore). */
+  excludePaths?: string[];
 }
 
 export async function scan(options: ScanOptions): Promise<ScanResult> {
   const startTime = Date.now();
   const { dir, packageName = 'unknown', packageVersion = null } = options;
 
+  // Load .safeskillignore up front so file-level excludes apply to discovery,
+  // not just to post-scan filtering.
+  const ignoreRules = await loadIgnoreRules(dir);
+  const extraIgnores = [
+    ...(options.excludePaths ?? []),
+    ...(ignoreRules?.fileGlobs ?? []),
+  ];
+
   // === LAYER 1: Fast Pass (parallel) ===
   const [patternResults, manifestResults, depResults, contentFiles] = await Promise.all([
-    analyzePatterns(dir),
+    analyzePatterns(dir, extraIgnores),
     analyzeManifest(dir),
     options.skipDeps ? Promise.resolve({ findings: [], dependencyCount: 0 }) : analyzeDependencies(dir),
-    discoverContent(dir),
+    discoverContent(dir, extraIgnores),
   ]);
 
   // === LAYER 2 + 2B: Deep Analysis (parallel) ===
   const [astResults, promptResults] = await Promise.all([
-    analyzeAST(dir, patternResults.flaggedFiles),
+    analyzeAST(dir, patternResults.flaggedFiles, extraIgnores),
     detectPromptInjection(contentFiles),
   ]);
 
@@ -55,7 +66,6 @@ export async function scan(options: ScanOptions): Promise<ScanResult> {
   let promptFindings: PromptFinding[] = promptResults.findings;
 
   // === Apply .safeskillignore rules (if present) ===
-  const ignoreRules = await loadIgnoreRules(dir);
   if (ignoreRules) {
     const filtered = applyIgnoreRules(codeFindings, promptFindings, taintFlows, ignoreRules);
     codeFindings = filtered.codeFindings;
@@ -78,6 +88,21 @@ export async function scan(options: ScanOptions): Promise<ScanResult> {
     mismatches,
   );
 
+  // If the AST layer couldn't read any source files, surface that loudly as a
+  // finding so consumers see why the score is capped instead of wondering why
+  // a package with no findings got a "caution" grade.
+  if (astResults.filesScanned === 0) {
+    codeFindings.push({
+      category: 'obfuscation',
+      severity: 'medium',
+      location: { file: 'package.json', line: 0, column: 0 },
+      description:
+        'Inconclusive: scanner found no analysable source files. The published artifact may ship only compiled bundles, non-JS code, or documentation. Score capped accordingly.',
+      codeSnippet: '',
+      confidence: 1.0,
+    });
+  }
+
   // === Calculate unified score ===
   const { overallScore, codeScore, contentScore, breakdown } = calculateScore(
     codeFindings,
@@ -92,6 +117,7 @@ export async function scan(options: ScanOptions): Promise<ScanResult> {
       hasRepository: manifestResults.hasRepository,
       hasTypes: manifestResults.hasTypes,
       packageType: manifestResults.packageType,
+      filesScanned: astResults.filesScanned,
     },
   );
 

--- a/packages/scanner/src/prompt-audit/detectors/tool-abuse.ts
+++ b/packages/scanner/src/prompt-audit/detectors/tool-abuse.ts
@@ -30,12 +30,40 @@ function snippet(content: string, index: number, length: number): string {
   return raw.replace(/\n/g, '\\n');
 }
 
+/**
+ * Returns true if the character offset falls inside a fenced code block
+ * (```lang ... ```). Markdown instructions that target an AI agent almost
+ * always live inside a code fence; human-onboarding prose does not.
+ */
+function isInsideCodeFence(content: string, offset: number): boolean {
+  let inFence = false;
+  const re = /```/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    if (m.index >= offset) break;
+    inFence = !inFence;
+  }
+  return inFence;
+}
+
+/**
+ * Signals that the surrounding paragraph is AI-directed rather than human-
+ * directed onboarding prose. "Run this", "execute the following", "tell the
+ * agent" — yes. "Add it to your shell profile" — no.
+ */
+const AI_DIRECTED_SIGNALS = /\b(?:agent|assistant|llm|claude|chatgpt|ai|run\s+this|execute\s+(?:this|the\s+following)|ignore\s+(?:previous|prior|all)|you\s+(?:must|should|will)\s+(?:run|execute|send|write|fetch))\b/i;
+
+function isMarkdownFile(filePath: string): boolean {
+  return /\.(?:md|mdx|markdown)(?::\d+)?$/i.test(filePath);
+}
+
 export function detect(
   content: string,
   filePath: string,
   isPriority: boolean,
 ): PromptFinding[] {
   const findings: PromptFinding[] = [];
+  const isMarkdown = isMarkdownFile(filePath);
 
   const allPatterns: Array<{ regex: RegExp; technique: string }> = [
     ...PROMPT_INJECTION_PATTERNS.toolAbuse.map((r) => ({
@@ -54,6 +82,26 @@ export function detect(
 
     while ((match = globalRe.exec(content)) !== null) {
       const { line, column } = lineColFromIndex(content, match.index);
+
+      // In markdown prose, a sentence like "Add it to your shell profile
+      // (~/.zshrc, ~/.bashrc) to persist across sessions" is user-facing
+      // onboarding, not an agent instruction. Require the match to live
+      // inside a code fence OR in a nearby window that is plausibly
+      // AI-directed. `dotfile-modification` / system-write patterns
+      // describing writes to /etc or ~/.ssh remain critical regardless
+      // of markdown context — those are specific, exploitable actions.
+      if (
+        isMarkdown &&
+        technique === 'tool-abuse-pattern' &&
+        !isInsideCodeFence(content, match.index)
+      ) {
+        const windowStart = Math.max(0, match.index - 120);
+        const windowEnd = Math.min(content.length, match.index + match[0].length + 120);
+        const windowText = content.slice(windowStart, windowEnd);
+        if (!AI_DIRECTED_SIGNALS.test(windowText)) {
+          continue;
+        }
+      }
 
       // Tool abuse is always critical
       const severity = 'critical' as const;

--- a/packages/scanner/src/scoring/calculator.ts
+++ b/packages/scanner/src/scoring/calculator.ts
@@ -22,7 +22,16 @@ export interface ScoreInput {
   hasRepository: boolean;
   hasTypes: boolean;
   packageType: PackageType;
+  /** How many source files the AST layer actually analysed. When 0 the
+   *  code scan produced no signal; we cannot claim the package is safe. */
+  filesScanned: number;
 }
+
+// When we fail to scan any source files (published tarball ships nothing
+// scannable, unreadable tree, etc.), this is the highest we're willing to
+// report. The grade maps to "caution" — the report surfaces the reason
+// instead of misleading consumers with a high green score.
+const INCONCLUSIVE_CODE_SCAN_CAP = 50;
 
 /**
  * Categories of findings that are EXPECTED for CLI tools.
@@ -181,16 +190,25 @@ export function calculateScore(
     overallScore = Math.min(overallScore, 10);
   }
 
+  // If no source files were scannable we cannot vouch for the package. Cap
+  // the score instead of letting "no findings" promote it to Verified Safe.
+  if (meta.filesScanned === 0) {
+    overallScore = Math.min(overallScore, INCONCLUSIVE_CODE_SCAN_CAP);
+  }
+
   overallScore = clamp(overallScore, 0, 100);
 
   // Calculate sub-scores
-  const codeScore = clamp(Math.round(
+  let codeScore = clamp(Math.round(
     (dangerousApis / SCORE_WEIGHTS.dangerousApis) * 25 +
     (dataFlowRisks / SCORE_WEIGHTS.dataFlowRisks) * 25 +
     (networkBehavior / SCORE_WEIGHTS.networkBehavior) * 20 +
     (dependencyHealth / SCORE_WEIGHTS.dependencyHealth) * 15 +
     (codeQuality / SCORE_WEIGHTS.codeQuality) * 15
   ), 0, 100);
+  if (meta.filesScanned === 0) {
+    codeScore = Math.min(codeScore, INCONCLUSIVE_CODE_SCAN_CAP);
+  }
 
   const contentScore = clamp(Math.round(
     (promptInjectionRisks / SCORE_WEIGHTS.promptInjectionRisks) * 50 +


### PR DESCRIPTION
## Summary

- **#12 — Local scan hang**: `skillsafe scan .` used to pin a core indefinitely on any checkout with a full `node_modules` because ts-morph loaded every matched file before we filtered. Discovery now runs through `globby` first with the ignore list applied up front, plus a 5,000-file safety cap, a `--exclude <glob...>` CLI flag, and `.safeskillignore` `file:` globs are honored at discovery time (not just post-filter).
- **#11 — `filesScanned: 0` with `codeScore: 100`**: published tarballs that ship only `dist/` now fall back to scanning the generated output instead of skipping everything. Package classification also fixed so that `faxdrop-mcp`-style packages (`bin` + `@modelcontextprotocol/sdk`) are categorized as `mcp-server` rather than `cli-tool`. When the AST layer still sees zero files, the overall score is capped at 50 and an explicit "inconclusive" finding is emitted.
- **#10 — SSH template strings / markdown shell-rc**: the sensitive-path regex no longer fires in `.tsx`/`.jsx`/`.vue`/`.svelte` files or in files without any fs context; the tool-abuse markdown rule now requires fenced-code or AI-directed framing, so "Add it to your shell profile (~/.zshrc)" in onboarding docs no longer reads as agent abuse.
- **#9 — long prompts, unicode bullets, localhost http**: long-line obfuscation rule now requires code-density and a non-string-literal majority; unicode-escape rule only counts escapes decoding to printable ASCII (box-drawing / bullet / CJK ignored); `http.request({ hostname: '127.0.0.1', ... })` is now recognized as localhost in both the network-access detector and the taint tracker; dynamic-require drills through `as const`, parens, satisfies, and non-null assertions so wrapped static literals stay literal.
- **#8 — MCP tool descriptions + ASCII banner**: covered by the #9 obfuscation changes (long-line skip for single-string lines, ASCII-only unicode filter).

CLI bumped to `0.3.2`.

## Test plan
- [x] `pnpm -r typecheck`
- [x] `pnpm -F @safeskill/scanner build`
- [x] `pnpm -F skillsafe build`
- [x] Smoke: scan full monorepo root (previously hung) — completes in ~22 s, `filesScanned: 178`.
- [x] Smoke: scan `packages/cli` — classifies as `cli-tool`, not `mcp-server`.
- [ ] User verification on `faxdrop-mcp`, `gmail-mcp`, `ChronoAIProject/NyxID`, `mmethodz/dreamgraph`, `alperhankendi/Ctxo`.

Closes #8 #9 #10 #11 #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)